### PR TITLE
大量のバグ修正

### DIFF
--- a/app/src/main/java/com/i14yokoro/tecterminal/EscapeSequence.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/EscapeSequence.java
@@ -79,16 +79,17 @@ public class EscapeSequence {
     }
 
     public void moveUp(int n){
-        //FIXME 追加できない，カーソル合わない，バグる
-        //たまにうまくいく
+
         if(termDisplay.getCursorY() - n < 0){ //画面外にでる
             termDisplay.setCursorY(0);
         } else {
             moveCursorY(-n);
             Log.d("termDisplay***","moveUp to y: " + Integer.toString(termDisplay.getCursorY()));
         }
-        if(termDisplay.getRowLength(getSelectRowIndex()) < termDisplay.getCursorX()){
-            int add = termDisplay.getCursorX() - termDisplay.getRowLength(getSelectRowIndex());
+        int rowLength = termDisplay.getRowLength(getSelectRowIndex());
+
+        if(rowLength < termDisplay.getCursorX()){
+            int add = termDisplay.getCursorX() - rowLength + 1;
             Log.d("termDisplay***","sub curX " + Integer.toString(add));
             addBlank(add);
         }
@@ -139,7 +140,6 @@ public class EscapeSequence {
     }
 
     public void moveDownToRowLead(int n){
-        //FIXME downがなおらないとうまくいかない
         termDisplay.setCursorX(0);
         moveDown(n);
     }
@@ -150,7 +150,6 @@ public class EscapeSequence {
     }
 
     public void moveSelection(int n, int m){ //n,mは1~
-        //FIXME downがなおらないとうまくいかない
         if(n < 1){
             n = 1;
         }
@@ -165,27 +164,32 @@ public class EscapeSequence {
 
     public void clearDisplay(){
         int x = termDisplay.getCursorX();
-        for(int y = termDisplay.getCursorY(); y < termDisplay.getDisplaySize(); y++){
-            for (; x < termDisplay.getRowLength(y); x++){
-                termDisplay.deleteTextItem(x, y);
+        int i = x;
+        int length;
+        int displaySize = termDisplay.getDisplaySize();
+        for(int y = termDisplay.getCursorY(); y < displaySize; y++){
+            length = termDisplay.getRowLength(y + getTop());
+            for (; i < length; i++){
+                if(termDisplay.getRowText(y + getTop()).length() > x) {
+                    termDisplay.deleteTextItem(x, y + getTop());
+                }
             }
             x = 0;
+            i = 0;
         }
     }
 
     public void clearDisplay(int n){
-        //FIXME きえかたがおかしい
         //一番下までスクロールして消去ぽい
         if(n == 0){ //カーソルより後ろにある画面上の文字を消す
             clearDisplay();
         }
 
-        //FIXME 入力中の行がきえない
         if(n == 1){ //カーソルより前にある画面上の文字を消す
-            for (int y = 0; y <= termDisplay.getCursorY(); y++){
+            for (int y = getTop(); y <= getSelectRowIndex(); y++){
                 for (int x = 0; x < termDisplay.getRowLength(y); x++){
                     termDisplay.changeText(x, y, " ");
-                    if(y == termDisplay.getCursorY()){
+                    if(y == getSelectRowIndex()){
                         if(x == termDisplay.getCursorX()){
                             break;
                         }
@@ -196,7 +200,7 @@ public class EscapeSequence {
 
         //FIXME 入力中の行がきえない
         if(n == 2){ //全消去
-            for (int y = 0; y < termDisplay.getDisplaySize(); y++){
+            for (int y = getTop(); y < termDisplay.getDisplaySize() + getTop(); y++){
                 for (int x = 0; x < termDisplay.getRowLength(y); x++){
                     termDisplay.changeTextItem(x, y, " ", termDisplay.getDefaultColor());
                 }
@@ -206,9 +210,9 @@ public class EscapeSequence {
     }
 
     public void clearRow(){
-        int del = termDisplay.getRowLength(termDisplay.getCursorY()) - termDisplay.getCursorX();
+        int del = termDisplay.getRowLength(getSelectRowIndex()) - termDisplay.getCursorX();
         for (int x = 0; x < del; x++){
-            termDisplay.deleteTextItem(termDisplay.getCursorX(), termDisplay.getCursorY());
+            termDisplay.deleteTextItem(termDisplay.getCursorX(), getSelectRowIndex());
         }
     }
 
@@ -219,15 +223,15 @@ public class EscapeSequence {
 
         if(n == 1){ //カーソル以前にある文字を消す
             for (int x = 0; x <= termDisplay.getCursorX(); x++){
-                termDisplay.changeText(x, termDisplay.getCursorY(), " ");
+                termDisplay.changeText(x, getSelectRowIndex(), " ");
                 //termDisplay.deleteTextItem(x, termDisplay.getCursorY());
             }
         }
 
         if(n == 2){ //全消去
-            int del = termDisplay.getRowLength(termDisplay.getCursorY());
+            int del = termDisplay.getRowLength(getSelectRowIndex());
             for (int x = 0; x < del; x++){
-                termDisplay.changeText(x, termDisplay.getCursorY(), " ");
+                termDisplay.changeText(x, getSelectRowIndex(), " ");
             }
 
         }

--- a/app/src/main/java/com/i14yokoro/tecterminal/EscapeSequence.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/EscapeSequence.java
@@ -29,11 +29,21 @@ public class EscapeSequence {
     }
 
     public void moveRight(){
-        moveCursorX(1);
+
+        if(termDisplay.getCursorX() >= termDisplay.getRowLength(getSelectRowIndex()) && termDisplay.getRowText(getSelectRowIndex()).lastIndexOf(LF) != -1){
+            termDisplay.setCursorX(termDisplay.getRowLength(getSelectRowIndex()));
+        } else {
+            moveCursorX(1);
+        }
     }
 
     public void moveLeft(){
-        moveCursorX(-1);
+
+        if(termDisplay.getCursorX() >= termDisplay.getRowLength(getSelectRowIndex()) && termDisplay.getRowText(getSelectRowIndex()).lastIndexOf(LF) != -1){
+            termDisplay.setCursorX(termDisplay.getRowLength(getSelectRowIndex()) - 2);
+        } else {
+            moveCursorX(-1);
+        }
     }
 
     public void moveUp(){
@@ -85,13 +95,7 @@ public class EscapeSequence {
 
     }
     public void moveDown(int n){
-        /**
-         * よころのあたまのなか
-         * からのやつつけるーしたいくーないーいっこしたでがまんーつけるーおわり
-         * だうんのとこでひとつつける必要ありそ？
-         */
-        //FIXME ２つ以上したにいくとカーソルが移動してくれないfk
-        //たぶんgetOffsetForPosition関係　（もしかしたらバグかも）
+
         if(termDisplay.getCursorY() + n >= termDisplay.getDisplaySize()) { //移動先が一番下の行を超える場合
             if(termDisplay.getCursorY() + n >= termDisplay.getDisplayColumnSize()){ //ディスプレイサイズを超える場合
                 termDisplay.setCursorY(termDisplay.getDisplayColumnSize() - 1);
@@ -99,13 +103,10 @@ public class EscapeSequence {
                 moveCursorY(n);
             }
             int move = termDisplay.getCursorY() - termDisplay.getDisplaySize();//2,1のばあい
-            //termDisplay.addTextItem(termDisplay.getTotalColumns()-1,LF, 0);
             for (int i = 0; i <= move; i++){
                 Log.d("termDisplay**", "add empty" + Integer.toString(i));
                 termDisplay.addEmptyRow();
             }
-            //
-            // termDisplay.setTextItem(" ", 0);
         }else { //移動先が一番下の行を超えない
             if (termDisplay.getCursorY() + n > termDisplay.getDisplaySize()) { //ディスプレイサイズを超える場合
                 termDisplay.setCursorY(termDisplay.getDisplayColumnSize() - 1);
@@ -126,10 +127,9 @@ public class EscapeSequence {
         if(x < 0){
             x = 0;
         }
-        for (int i = 0; i <= n; i++){
+        for (int i = 0; i < n; i++){
             Log.d("termDisplay**", "add Blank"+Integer.toString(i));
             termDisplay.insertTextItem(x, getSelectRowIndex(),"p", termDisplay.getDefaultColor());
-            //termDisplay.addTextItem(termDisplay.getTopRow()+termDisplay.getCursorY(), "d", 0);
         }
     }
 
@@ -291,10 +291,12 @@ public class EscapeSequence {
         termDisplay.createDisplay();
         TimingLogger logger = new TimingLogger("TAG_TEST", "change display");
         int totalColumns = termDisplay.getTotalColumns();
-        int displayColumnsSize = termDisplay.getDisplaySize();
+        int displaySize = termDisplay.getDisplaySize();
         int displayRowSize = termDisplay.getDisplayRowSize();
+        int dispayColumnSize = termDisplay.getDisplayColumnSize();
 
-        for (int y = 0; y < totalColumns && y < displayColumnsSize; y++){
+
+        for (int y = 0; y < totalColumns && y < displaySize; y++){
             for (int x = 0; x < displayRowSize; x++){
                 Log.d("termDisplay", "y "+Integer.toString(y));
                 if(!termDisplay.getDisplay(x, y).equals("EOL")) {
@@ -305,11 +307,13 @@ public class EscapeSequence {
                         }
                         break;
                     }
-                    if(!colorChange){
-                        output = output + termDisplay.getDisplay(x, y);
-                    } else {
-                        output = output + "<font color=#" + termDisplay.getColor(x, getTop() + y) +
-                                ">" + termDisplay.getDisplay(x, y) + "</font>";
+                    if(y < dispayColumnSize-1) {
+                        if (!colorChange) {
+                            output = output + termDisplay.getDisplay(x, y);
+                        } else {
+                            output = output + "<font color=#" + termDisplay.getColor(x, getTop() + y) +
+                                    ">" + termDisplay.getDisplay(x, y) + "</font>";
+                        }
                     }
                 } else{
                     Log.d("termDisplay**", "here is EOL");
@@ -323,7 +327,7 @@ public class EscapeSequence {
                     logger.dumpToLog();
                     return;
                 }
-                if(x == displayRowSize-1){
+                if((x == displayRowSize-1) && !termDisplay.getDisplay(x, y).equals(LF)){
                     Log.d("termDisplay**", "max size");
                     output = output + LF;
                     //editText.append(LF);

--- a/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
@@ -1142,19 +1142,22 @@ public class MainActivity extends AppCompatActivity{
             Log.d("termDisplay***", "text length  " + termDisplay.getRowLength(termDisplay.getTopRow() + i));
             if (termDisplay.getRowLength(termDisplay.getTopRow() + i) == 0){
                 length++;
-            }
-            if (termDisplay.getRowText(termDisplay.getTopRow() + i).lastIndexOf(LF) == -1){
-                length++;
+            } else {
+                if (!termDisplay.getRowText(termDisplay.getTopRow() + i).contains(LF)) {
+                    length++;
+                }
             }
         }
+
+        Log.d("termDisplay***", "after fot length : " + length);
 
         int rowLength = termDisplay.getRowLength(termDisplay.getTopRow() + y);
 
         //空
-        if(rowLength == 0) length++;
+        if(rowLength == 0) x = 0;
         Log.d("termDisplay***", "X: " + x + " y length  " + termDisplay.getRowLength(y));
         //移動先の文字数がカーソルXよりも短い
-        if (x > rowLength ){//&& termDisplay.getRowText(getSelectRowIndex()).lastIndexOf(LF) != -1){
+        if (x > rowLength && rowLength != 0){//&& termDisplay.getRowText(getSelectRowIndex()).lastIndexOf(LF) != -1){
             x = rowLength - 1;
         }
         //カーソルXが移動先の文字数と等しくて，改行コードが存在する

--- a/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
@@ -516,7 +516,9 @@ public class MainActivity extends AppCompatActivity{
                             Log.d(TAG, "ASCII code/ " + str);
                             if (inputStr.equals(LF)) {
                                 termDisplay.setCursorX(0);
-                                moveCursorY(1);
+                                if (termDisplay.getCursorY() + 1 < termDisplay.getDisplayColumnSize()) {
+                                    moveCursorY(1);
+                                }
                                 changeDisplay();
 
                                 if (inputEditText.getLineCount() >= termDisplay.getDisplayColumnSize()) {
@@ -537,7 +539,9 @@ public class MainActivity extends AppCompatActivity{
                                 inputEditText.append(LF);
                                 //termDisplay.setCursorX();
                                 termDisplay.setCursorX(0);
-                                moveCursorY(1);
+                                if (termDisplay.getCursorY() + 1 < termDisplay.getDisplayColumnSize()) {
+                                    moveCursorY(1);
+                                }
                                 enterPutFlag = true;
                                 displayingFlag = false;
                                 receivingFlag = true;
@@ -603,6 +607,8 @@ public class MainActivity extends AppCompatActivity{
         return intentFilter;
     }
 
+
+    //FIXME 一番下の行での入力が表示されない
     private final BroadcastReceiver bleServiceReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
@@ -629,7 +635,7 @@ public class MainActivity extends AppCompatActivity{
                     for (byte b : utf){
                         str = Integer.toHexString(b & 0xff);
                         Log.d(TAG, "coming HEX : " + str);
-                        bleService.writeMLDP(str + " ");
+                        //bleService.writeMLDP(str + " ");
                     }
 
                     int startSel = inputEditText.getSelectionStart();
@@ -668,12 +674,15 @@ public class MainActivity extends AppCompatActivity{
                             escapeMoveFlag = false;
                         default:
                             //2桁の入力を可能にする　できた
-                            h1 = 1;
 
                             if (squarePuttingFlag && data.matches("[0-9]")) {
                                 Log.d(TAG, "move flag is true");
                                 escapeMoveNum += data;
                                 clear += data;
+                                if (Integer.parseInt(escapeMoveNum) > 1000 || Integer.parseInt(clear) > 1000){
+                                    escapeMoveNum = "1000";
+                                    clear = "1000";
+                                }
                                 escapeMoveFlag = true;
                                 //squarePuttingFlag = false;
                                 break;
@@ -712,48 +721,83 @@ public class MainActivity extends AppCompatActivity{
 
                                     Log.d(TAG, "moveFlag true && A-H");
                                     if (str.equals(KeyHexString.KEY_A)) {
+                                        if (move >= termDisplay.getDisplayColumnSize()) move = termDisplay.getDisplayColumnSize()-1;
                                         escapeSequence.moveUp(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_B)) {
+                                        if (move >= termDisplay.getDisplayColumnSize()) move = termDisplay.getDisplayColumnSize()-1;
                                         escapeSequence.moveDown(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_C)) {
+                                        if (move >= termDisplay.getDisplayRowSize()) move = termDisplay.getDisplayRowSize()-1;
                                         escapeSequence.moveRight(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_D)) {
+                                        if (move >= termDisplay.getDisplayRowSize()) move = termDisplay.getDisplayRowSize()-1;
                                         escapeSequence.moveLeft(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_E)) {
+                                        if (move >= termDisplay.getDisplayColumnSize()) move = termDisplay.getDisplayColumnSize()-1;
                                         escapeSequence.moveDownToRowLead(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_F)) {
+                                        if (move >= termDisplay.getDisplayColumnSize()) move = termDisplay.getDisplayColumnSize()-1;
                                         escapeSequence.moveUpToRowLead(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_G)) {
+                                        if (move >= termDisplay.getDisplayRowSize()) move = termDisplay.getDisplayRowSize()-1;
                                         escapeSequence.moveSelection(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_H) || str.equals(KeyHexString.KEY_f)) {
                                         if (!Hflag) {
                                             h1 = 1;
                                             move = 1;
                                         }
+                                        if (h1 >= termDisplay.getDisplayColumnSize()) h1 = termDisplay.getDisplayColumnSize()-1;
+                                        if (move >= termDisplay.getDisplayRowSize()) move = termDisplay.getDisplayRowSize()-1;
                                         escapeSequence.moveSelection(h1, move);
                                         Hflag = false;
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_J)) {
                                         escapeSequence.clearDisplay(clearNum);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_K)) {
                                         escapeSequence.clearRow(clearNum);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_S)) {
                                         escapeSequence.scrollNext(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_T)) {
                                         escapeSequence.scrollBack(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     if (str.equals(KeyHexString.KEY_m)){
                                         escapeSequence.selectGraphicRendition(move);
+                                        escapeMoveNum = "";
+                                        clear = "";
                                     }
                                     changeDisplay();
                                     escapeMoveFlag = false;
@@ -768,8 +812,10 @@ public class MainActivity extends AppCompatActivity{
                             escPuttingFlag = false;
                             squarePuttingFlag = false;
                             receivingFlag = false;
-                            editable.replace(Math.min(startSel, endSel), Math.max(startSel, endSel), data);
+                            editable.replace(termDisplay.getCursorX(), termDisplay.getCursorX(), data);
+                            //termDisplay.setTextItem(data, termDisplay.getDefaultColor());
                             //input.append(str);
+                            changeDisplay();
                             receivingFlag = true;
                             escapeMoveFlag = false;
 
@@ -1138,7 +1184,9 @@ public class MainActivity extends AppCompatActivity{
 
     private void scrollUp(){
         if(termDisplay.getTopRow() -1 >= 0){
-            moveCursorY(1);
+            if (termDisplay.getCursorY() + 1 < termDisplay.getDisplayColumnSize()) {
+                moveCursorY(1);
+            }
             termDisplay.addTopRow(-1);
             changeDisplay();
         }

--- a/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
@@ -33,8 +33,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
-import android.view.ViewTreeObserver;
-import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -113,16 +111,6 @@ public class MainActivity extends AppCompatActivity{
     private boolean displayingFlag = false;
 
     private int h1;
-    private boolean isHFlag = false;
-    private boolean isfFlag = false;
-    private boolean isBFlag = false;
-
-    private Window mRootWindow;
-
-    private int diffHeight = 0;
-    private int beforeHeight = 0;
-    private boolean isShowingKeyBoard = false;
-
 
     @SuppressLint("ClickableViewAccessibility")
     @Override
@@ -259,18 +247,6 @@ public class MainActivity extends AppCompatActivity{
             @Override
             public void onClick(View v) {
 
-                //escapeSequence.moveSelection(3,5);
-                escapeSequence.moveDown(3);
-                //isHFlag = true;
-                //escapeSequence.moveUp(3);
-                //termDisplay.insertTextItem(termDisplay.getCursorX(), getSelectRowIndex(), "d", termDisplay.getDefaultColor());
-                //escapeSequence.moveDownToRowLead(3);
-                //escapeSequence.moveSelection(5);
-                //escapeSequence.clearDisplay(1);
-                //escapeSequence.clearRow(2);
-
-                //termDisplay.setDefaultColor("FF0000");
-
                 changeDisplay();
                 isBtn_esc = true;
                 Log.d(TAG, "max column: " + maxColumnLength);
@@ -284,33 +260,7 @@ public class MainActivity extends AppCompatActivity{
                 isBtn_ctl = true;
                 showListContents();
                 showDisplay();
-                TimingLogger logger = new TimingLogger("TAG_TEST", "move selection");
-                //changeDisplay();
-                //Log.d("termDisplay**","start: " + inputEditText.getText().toString());
-                //escapeSequence.moveSelection(3,5);
-                //escapeSequence.moveUpToRowLead(3);
-                //escapeSequence.clearDisplay(2);
-                //escapeSequence.clearRow(1);
-                //termDisplay.setDefaultColor("008000");
-                //changeDisplay();
-                //Log.d("termDisplay**","end: " +  inputEditText.getText().toString());
-                //Log.d("termDisplay**", "getSelectionStart"+Integer.toString(inputEditText.getSelectionStart()));
-                //changeDisplay();
-                //moveToSavedCursor();
-                //inputEditText.setSelection(inputEditText.length());
-
-
-                Log.d("termDisplay***", "view height is "+ diffHeight + ", " + inputEditText.getHeight());
-                /**
-                 * これでだめ←？？？？？
-                escapeSequence.moveSelection(5,5);
-                changeDisplay();
-                moveToSavedCursor();
-                 **/
-
                 Log.d("termDisplay**", Integer.toString(getSelectRowIndex()));
-                logger.dumpToLog();
-
             }
         });
 
@@ -379,23 +329,6 @@ public class MainActivity extends AppCompatActivity{
                 return false;
             }
         });
-
-        //レイアウトの大きさがかわると通知
-        inputEditText.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-            public void onGlobalLayout(){
-                // r.left, r.top, r.right, r.bottom
-                diffHeight = inputEditText.getHeight() - beforeHeight;
-                beforeHeight = inputEditText.getHeight();
-                if (diffHeight < - 150){
-                    isShowingKeyBoard = true;
-                } else {
-                    isShowingKeyBoard = false;
-                }
-
-            }
-        });
-
-
     }
 
     @Override
@@ -789,7 +722,6 @@ public class MainActivity extends AppCompatActivity{
                                     }
                                     if (str.equals(KeyHexString.KEY_B)) {
                                         escapeSequence.moveDown(move);
-                                        isBFlag = true;
                                     }
                                     if (str.equals(KeyHexString.KEY_C)) {
                                         escapeSequence.moveRight(move);
@@ -812,7 +744,6 @@ public class MainActivity extends AppCompatActivity{
                                             move = 1;
                                         }
                                         escapeSequence.moveSelection(h1, move);
-                                        isHFlag = true;
                                         Hflag = false;
                                     }
                                     if (str.equals(KeyHexString.KEY_J)) {

--- a/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
@@ -40,8 +40,12 @@ import android.widget.EditText;
 import java.nio.charset.StandardCharsets;
 
 /**
- * TODO あらたなエスケープシーケンスの追加（行単位でやるよりらくになったはず）
  * TODO スクロールしたとき一番下の行が空白でカーソルが残るのを直す
+ * これからやること
+ * //TODO バグ潰し（バグしかない）
+ * //TODO escBとHのカーソル移動がうまくいかないので力づくでやる（原因不明）
+ * //TODO RNからきたエスケープシーケンス受信部の作成
+ * //TODO 基本文字は上書きにする
  */
 public class MainActivity extends AppCompatActivity{
 
@@ -787,7 +791,6 @@ public class MainActivity extends AppCompatActivity{
                                         escapeSequence.scrollBack(move);
                                     }
                                     if (str.equals(KeyHexString.KEY_m)){
-                                        //TODO 引数かえる
                                         escapeSequence.selectGraphicRendition(move);
                                     }
                                     changeDisplay();

--- a/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
@@ -80,6 +80,8 @@ public class MainActivity extends AppCompatActivity{
     private State state = State.STARTING;
 
     private String escapeMoveNum = ""; //escapeシーケンスできたString型の数字を保存
+    private String clear = "";
+    private int h1;
 
     private Editable editable;
     private EscapeSequence escapeSequence;
@@ -109,8 +111,6 @@ public class MainActivity extends AppCompatActivity{
 
     private boolean receivingFlag = true; //RN側に送りたくないものがあるときはfalseにする
     private boolean displayingFlag = false;
-
-    private int h1;
 
     @SuppressLint("ClickableViewAccessibility")
     @Override
@@ -152,10 +152,6 @@ public class MainActivity extends AppCompatActivity{
                     escapeSequence.moveUp();
                     moveToSavedCursor();
                 }
-                /**
-                if(false/* 画面一番上でだったら) {
-                    scrollUp();
-                }**/
             }
         });
 
@@ -180,10 +176,6 @@ public class MainActivity extends AppCompatActivity{
                     escapeSequence.moveDown();
                     moveToSavedCursor();
                 }
-                /**
-                if(false/* 画面一番下でだったら) {
-                    scrollDown();
-                }**/
             }
         });
 
@@ -233,22 +225,18 @@ public class MainActivity extends AppCompatActivity{
                     moveToSavedCursor();
                 }
                 logger.dumpToLog();
-                /**
-                if(currX < 0){
-                    //currX = 0;
-                    if(currY > 0){
-                        //currY--;
-                    }
-                }***/
             }
         });
 
         findViewById(R.id.btn_esc).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-
                 changeDisplay();
                 isBtn_esc = true;
+
+                //escapeSequence.moveUp(3);
+                escapeSequence.clearDisplay(0);
+                changeDisplay();
                 Log.d(TAG, "max column: " + maxColumnLength);
 
             }
@@ -260,6 +248,9 @@ public class MainActivity extends AppCompatActivity{
                 isBtn_ctl = true;
                 showListContents();
                 showDisplay();
+
+                escapeSequence.clearDisplay(2);
+                changeDisplay();
                 Log.d("termDisplay**", Integer.toString(getSelectRowIndex()));
             }
         });
@@ -682,6 +673,7 @@ public class MainActivity extends AppCompatActivity{
                             if (squarePuttingFlag && data.matches("[0-9]")) {
                                 Log.d(TAG, "move flag is true");
                                 escapeMoveNum += data;
+                                clear += data;
                                 escapeMoveFlag = true;
                                 //squarePuttingFlag = false;
                                 break;
@@ -708,11 +700,13 @@ public class MainActivity extends AppCompatActivity{
                                 if (data.matches("[A-HJKSTfm]")) {
                                     //escapeシーケンス用
                                     int move;
-                                    int topRow = termDisplay.getTopRow();
+                                    int clearNum;
                                     if (escapeMoveFlag) {
                                         move = Integer.parseInt(escapeMoveNum);
+                                        clearNum = Integer.parseInt(clear);
                                     } else {
                                         move = 1;
+                                        clearNum = 0;
                                     }
                                     escapeMoveNum = "";
 
@@ -747,10 +741,10 @@ public class MainActivity extends AppCompatActivity{
                                         Hflag = false;
                                     }
                                     if (str.equals(KeyHexString.KEY_J)) {
-                                        escapeSequence.clearDisplay(move);
+                                        escapeSequence.clearDisplay(clearNum);
                                     }
                                     if (str.equals(KeyHexString.KEY_K)) {
-                                        escapeSequence.clearRow(move);
+                                        escapeSequence.clearRow(clearNum);
                                     }
                                     if (str.equals(KeyHexString.KEY_S)) {
                                         escapeSequence.scrollNext(move);

--- a/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
@@ -1112,41 +1112,65 @@ public class MainActivity extends AppCompatActivity{
         termDisplay.setCursorY(termDisplay.getCursorY() + y);
     }
 
-    private void moveCursor(int x, int y){
-        int cursor = inputEditText.getOffsetForPosition(x * getTextWidth()+2, y * getTextHeight()+2);
-        if(cursor > 0){
-            inputEditText.setSelection(cursor);
-        }
-    }
-
     private void moveToSavedCursor(){
         if(!selectionMovingFlag) {
             selectionMovingFlag = true;
             Log.d(TAG, "moveToSavedCursor()");
-            Log.d("termDisplay**", "list size: " + termDisplay.getTotalColumns() +
-                    " /row size: " + termDisplay.getRowLength(getSelectRowIndex()));
+            //Log.d("termDisplay**", "list size: " + termDisplay.getTotalColumns() +
+              //      " /row size: " + termDisplay.getRowLength(getSelectRowIndex()));
             String str = termDisplay.getRowText(getSelectRowIndex());
             //str.replace(LF, "_");
             Log.d("termDisplay**", "row contents: " + str);
-            Log.d("termDisplay***", "length" + Integer.toString(inputEditText.length()));
+            //Log.d("termDisplay***", "length" + Integer.toString(inputEditText.length()));
+            int cursor;
+            cursor = getRowLength(termDisplay.getCursorX(), termDisplay.getCursorY());
 
-            int cursor = inputEditText.getOffsetForPosition(termDisplay.getCursorX() * getTextWidth(), termDisplay.getCursorY() * getTextHeight());
-            Log.d("termDisplay***", "text size  " + getTextWidth() + ", " + getTextHeight());
+            //Log.d("termDisplay***", "text size  " + getTextWidth() + ", " + getTextHeight());
             Log.d("termDisplay***", "moved to " + termDisplay.getCursorX() + ", " + termDisplay.getCursorY());
-            //FIXME 文字数が７あるのにcursorが１になる．(エスケープBとHのとき)　移動前の行がmaxだったらうまくいく模様
             if (cursor >= 0) {
-                //Log.d(TAG, "moved to " + termDisplay.getCursorX() + ", " + termDisplay.getCursorY());
                 inputEditText.setSelection(cursor);
-                //inputEditText.setSelection(inputEditText.length());
                 Log.d("termDisplay***", "cursor" + cursor);
             }
             selectionMovingFlag = false;
         }
     }
 
-    private void setCursor(int x, int y){
-        termDisplay.setCursorX(x);
-        termDisplay.setCursorY(y);
+    private int getRowLength(int x, int y){
+        int length = 0;
+        for (int i = 0; i < y; i++){
+            length = length + termDisplay.getRowLength(termDisplay.getTopRow() + i);
+            Log.d("termDisplay***", "text length  " + termDisplay.getRowLength(termDisplay.getTopRow() + i));
+            if (termDisplay.getRowLength(termDisplay.getTopRow() + i) == 0){
+                length++;
+            }
+            if (termDisplay.getRowText(termDisplay.getTopRow() + i).lastIndexOf(LF) == -1){
+                length++;
+            }
+        }
+
+        int rowLength = termDisplay.getRowLength(termDisplay.getTopRow() + y);
+
+        //空
+        if(rowLength == 0) length++;
+        Log.d("termDisplay***", "X: " + x + " y length  " + termDisplay.getRowLength(y));
+        //移動先の文字数がカーソルXよりも短い
+        if (x > rowLength ){//&& termDisplay.getRowText(getSelectRowIndex()).lastIndexOf(LF) != -1){
+            x = rowLength - 1;
+        }
+        //カーソルXが移動先の文字数と等しくて，改行コードが存在する
+        if(x == rowLength && termDisplay.getRowText(termDisplay.getTopRow() + y).lastIndexOf(LF) != -1){
+            x = rowLength-1;
+        }
+        //if (rowLength == termDisplay.getDisplayRowSize()){
+          //  if (termDisplay.getRowText(termDisplay.getTopRow() + y).lastIndexOf(LF) == -1){
+            //    x = rowLength-1;
+            //}
+        //}
+        length = length + x;
+        if (length > inputEditText.length()){
+            length = inputEditText.length();
+        }
+        return length;
     }
 
     private void scrollUp(){

--- a/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/MainActivity.java
@@ -139,14 +139,6 @@ public class MainActivity extends AppCompatActivity{
                 if(state == State.CONNECTED) {
                     bleService.writeMLDP("\u001b" + "[1A");
                 }
-                else {
-                    //if (items.get(getSelectRow()).isWritable()){
-                        //escapeSequence.moveUp();
-                        //if(!items.get(getSelectRow()).isWritable()){
-                        //    inputEditText.setSelection(currCursor);
-                       // }
-                   // }
-                }
 
                 if(termDisplay.getCursorY() > 0){
                     escapeSequence.moveUp();
@@ -162,15 +154,6 @@ public class MainActivity extends AppCompatActivity{
                 if(state == State.CONNECTED) {
                     bleService.writeMLDP("\u001b" + "[1B");
                 }
-                else {
-                    /**
-                    if (items.get(getSelectRowIndex()).isWritable()){
-                        escapeSequence.moveDown();
-                        if(!items.get(getSelectRowIndex()).isWritable()){
-                            inputEditText.setSelection(currCursor);
-                        }
-                    }**/
-                }
 
                 if(termDisplay.getCursorY() < inputEditText.getLineCount()-1) {
                     escapeSequence.moveDown();
@@ -185,23 +168,11 @@ public class MainActivity extends AppCompatActivity{
                 if(state == State.CONNECTED) {
                     bleService.writeMLDP("\u001b" + "[1C");
                 }
-                else {
-                    /**
-                    if (items.get(getSelectRowIndex()).isWritable()){
-                        escapeSequence.moveRight();
-                        if(!items.get(getSelectRowIndex()).isWritable()){
-                            inputEditText.setSelection(currCursor);
-                        }
-                    }**/
-                }
+
                 if(termDisplay.getCursorX() < termDisplay.getRowLength(getSelectRowIndex())) {
                     escapeSequence.moveRight();
                     moveToSavedCursor();
                 }
-                //if(termDisplay.getDisplay(currX, currY).equals(LF) || currX > maxRowLength){
-                    //currX = 0;
-                    //currY++;
-                //}
             }
         });
         findViewById(R.id.btn_left).setOnClickListener(new View.OnClickListener() {
@@ -210,33 +181,18 @@ public class MainActivity extends AppCompatActivity{
                 if(state == State.CONNECTED) {
                     bleService.writeMLDP("\u001b" + "[1D");
                 }
-                else {
-                    /**
-                    if (items.get(getSelectRowIndex()).isWritable()){
-                        escapeSequence.moveLeft();
-                        if(!items.get(getSelectRowIndex()).isWritable()){
-                            inputEditText.setSelection(currCursor);
-                        }
-                    }**/
-                }
-                TimingLogger logger = new TimingLogger("TAG_TEST", "move left");
+
                 if(termDisplay.getCursorX() > 0) {
                     escapeSequence.moveLeft();
                     moveToSavedCursor();
                 }
-                logger.dumpToLog();
             }
         });
 
         findViewById(R.id.btn_esc).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                changeDisplay();
                 isBtn_esc = true;
-
-                //escapeSequence.moveUp(3);
-                escapeSequence.clearDisplay(0);
-                changeDisplay();
                 Log.d(TAG, "max column: " + maxColumnLength);
 
             }
@@ -246,11 +202,6 @@ public class MainActivity extends AppCompatActivity{
             @Override
             public void onClick(View v) {
                 isBtn_ctl = true;
-                showListContents();
-                showDisplay();
-
-                escapeSequence.clearDisplay(2);
-                changeDisplay();
                 Log.d("termDisplay**", Integer.toString(getSelectRowIndex()));
             }
         });

--- a/app/src/main/java/com/i14yokoro/tecterminal/TermDisplay.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/TermDisplay.java
@@ -240,7 +240,6 @@ public class TermDisplay {
                 break;
             }
             if((y >= totalColumns || y+topRow >= totalColumns)){ //yがリストよりでかくなったら
-                //FIXME 最後に空白入るのここらへんが原因
                 setDisplay(textList.get(totalColumns-1).size(), displayY, "EOL"); //最後に "EOL" という目印をつける
                 break;
             }

--- a/app/src/main/java/com/i14yokoro/tecterminal/TermDisplay.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/TermDisplay.java
@@ -109,10 +109,15 @@ public class TermDisplay {
             checkLF = 0;
         }
         if(y < this.textList.size() && x <= this.textList.get(y).size()) {
+            if (getRowLength(y) >= displayRowSize && getText(displayRowSize-1, y).equals(LF)){
+                deleteTextItem(displayRowSize-1, y);
+            }
+            Log.d(TAG, "insert to :" + x + ", " + y);
             if(textList.get(y).size() < displayRowSize && !getText(checkLF, y).equals(LF)) {
                 //if(getRowText(getCursorY()).lastIndexOf(LF) == )
                 TextItem textItem = new TextItem(text, color);
                 this.textList.get(y).add(x, textItem);
+
             }
         }
     }
@@ -127,7 +132,7 @@ public class TermDisplay {
         if(y < this.textList.size() && x < this.textList.get(y).size()) {
             return this.textList.get(y).get(x).getText();
         } else {
-            return null;
+            return "";
         }
     }
 

--- a/app/src/main/java/com/i14yokoro/tecterminal/TermDisplay.java
+++ b/app/src/main/java/com/i14yokoro/tecterminal/TermDisplay.java
@@ -116,8 +116,15 @@ public class TermDisplay {
             if(textList.get(y).size() < displayRowSize && !getText(checkLF, y).equals(LF)) {
                 //if(getRowText(getCursorY()).lastIndexOf(LF) == )
                 TextItem textItem = new TextItem(text, color);
-                this.textList.get(y).add(x, textItem);
-
+                textList.get(y).add(x, textItem);
+            } else {
+                if(getText(checkLF, y).equals(LF)){
+                    deleteTextItem(checkLF, y);
+                    TextItem textItem = new TextItem(text, color);
+                    textList.get(y).add(checkLF, textItem);
+                    textItem = new TextItem(LF, color);
+                    textList.get(y).add(textItem);
+                }
             }
         }
     }


### PR DESCRIPTION
やったこと
・エスケープシーケンスの大きな動作バグの修正
・カーソル移動の移動方法の変更

これからやること
・受信した文字に対するカーソル移動がおかしい
・エスケープシーケンスの軽微なバグ
・途中の書き込みに対応させる
・ボタンでの移動は横でしか移動できないようにする
・文字は上書きにする
・RNからきたエスケープシーケンス受信部の作成
・スクロールしたとき一番下の行が空白でカーソルが残るのを直す